### PR TITLE
Fixes compilation errors with HashMap and HashSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,5 +8,5 @@ dependencies = [
 [[package]]
 name = "image"
 version = "0.1.0"
-source = "git+https://github.com/PistonDevelopers/image#475682495f1a8626ecca217a1abd79c450528302"
+source = "git+https://github.com/PistonDevelopers/image#4d83ec4e6abc2bdfce3da3e5f49762728b9f5617"
 

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1,6 +1,6 @@
 //! Basic DOM data structures.
 
-use std::collections::hashmap::{HashMap, HashSet};
+use std::collections::{HashMap,HashSet};
 
 pub type AttrMap = HashMap<String, String>;
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -11,7 +11,7 @@
 //! * Character entities
 
 use dom;
-use std::collections::hashmap::HashMap;
+use std::collections::HashMap;
 
 /// Parse an HTML document and return the root element.
 pub fn parse(source: String) -> dom::Node {

--- a/src/style.rs
+++ b/src/style.rs
@@ -5,7 +5,7 @@
 
 use dom::{Node, Element, ElementData, Text};
 use css::{Stylesheet, Rule, Selector, Simple, SimpleSelector, Value, Keyword, Specificity};
-use std::collections::hashmap::HashMap;
+use std::collections::HashMap;
 
 /// Map from CSS property names to values.
 pub type PropertyMap =  HashMap<String, Value>;


### PR DESCRIPTION
As of rust-lang/rust commit e84e7a00ddec76570bbaa9afea385d544f616814
HashMap and HashSet can be found at std::collections::{HashMap,HashSet}
and are no longer under std::collections::hashmap.

Signed-off-by: zachwick zach@zachwick.com
