### PR TITLE
Add link href support.

### DIFF
--- a/examples/test.html
+++ b/examples/test.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>Test</title>
+    <link href="examples/test.css"></link>
   </head>
   <div class="outer">
     <p class="inner">

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -41,6 +41,24 @@ pub fn elem(name: String, attrs: AttrMap, children: Vec<Node>) -> Node {
     }
 }
 
+impl Node {
+    pub fn get_elements_by_tag_name(&self, name: &str) -> Vec<&Node> {
+        let mut results = Vec::new();
+        match self.node_type {
+            Element(ref element_data) => {
+                if element_data.tag_name.as_slice() == name {
+                    results.push(self);
+                }
+                for child in self.children.iter() {
+                    results.extend(child.get_elements_by_tag_name(name).into_iter());
+                }
+            },
+            Text(_) => (),
+        }
+        results
+    }
+}
+
 // Element methods
 
 impl ElementData {


### PR DESCRIPTION
So I've implemented basic `link` support. I'm pretty sure you don't want to merge it because you don't want this toy browser to grow uncontrollably. But I wanted to leave it here and discuss a little bit.

So the tricky thing here is that I implemented `get_elements_by_tag_name` on `Node`. But it is not a `Node` method but rather `Element` method. But `Element` itself in our case (`ElementData`) does not have `children` available.
I'm not really sure what to think about the relationship between `Element` and `Node`. It's like `Element` is a type of `Node` but with limited functionality. It's not inheritance either.

I checked and servo's `Element` simply has `Node` inside of it. And

``` rust
    fn GetElementsByTagName(self, localname: DOMString) -> Temporary<HTMLCollection> {
        let window = window_from_node(self).root();
        HTMLCollection::by_tag_name(*window, NodeCast::from_ref(self), localname)
    }
```

is casting `Element` onto `Node`. Is this cast something more than just `self.node`?
