### PR TITLE
Fix typo ('Unknow' to 'Unknown')

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
         Some(format) => match &*format {
             "png" => true,
             "pdf" => false,
-            _ => panic!("Unknow output format: {}", format),
+            _ => panic!("Unknown output format: {}", format),
         }
     };
 


### PR DESCRIPTION
Fix typo in `panic!` macro ('Unknow' to 'Unknown')