### PR TITLE
Fix unnecessary parentheses warning around `for`

### DIFF
--- a/src/painting.rs
+++ b/src/painting.rs
@@ -116,8 +116,8 @@ impl Canvas {
                 let x1 = (rect.x + rect.width).clamp(0.0, self.width as f32) as usize;
                 let y1 = (rect.y + rect.height).clamp(0.0, self.height as f32) as usize;
 
-                for y in (y0 .. y1) {
-                    for x in (x0 .. x1) {
+                for y in y0 .. y1 {
+                    for x in x0 .. x1 {
                         // TODO: alpha compositing with existing pixel
                         self.pixels[y * self.width + x] = color;
                     }


### PR DESCRIPTION
I got the following warnings when compiling by rustc 1.7.0:

warning: unnecessary parentheses around `for` head
expression, #[warn(unused_parens)] on by default