### PR TITLE
Remove deprecated module

### DIFF
--- a/src/css.rs
+++ b/src/css.rs
@@ -3,8 +3,6 @@
 //! To support more CSS syntax, it would probably be easiest to replace this
 //! hand-rolled parser with one based on a library or parser generator.
 
-use std::ascii::AsciiExt; // for `to_ascii_lowercase`
-
 // Data structures:
 
 #[derive(Debug)]


### PR DESCRIPTION
As a warning after Rust 1.26, we can use inherent method instead so
we'll no need to `use` the `AsciiExt`.

Ref: https://doc.rust-lang.org/std/ascii/trait.AsciiExt.html